### PR TITLE
Fix errors with Blade parsing

### DIFF
--- a/resources/views/item.blade.php
+++ b/resources/views/item.blade.php
@@ -1,4 +1,4 @@
-<li class="@if($item->getItemClass()){{ $item->getItemClass() }}@endif @if($active)active@endif @if($item->hasItems())treeview@endif clearfix">
+<li class="@if($item->getItemClass()){{ $item->getItemClass() }}@endif @if($active)active @endif @if($item->hasItems())treeview @endif clearfix">
     <a href="{{ $item->getUrl() }}" class="@if(count($appends) > 0) hasAppend @endif" @if($item->getNewTab())target="_blank"@endif>
         <i class="{{ $item->getIcon() }}"></i>
         <span>{{ $item->getName() }}</span>


### PR DESCRIPTION
For some reason, if `@endif` is directly next to a bare string it doesn't parse correctly. This is one way to fix it, another would be to wrap them in Blade "echo" tags: `{{ 'active' }}@endif`

This was introduced in #27 and fixes #28.