### PR TITLE
Better Active state checking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/cache": "~5.0",
-    "illuminate/container": "~5.0",
-    "illuminate/contracts": "~5.0",
-    "illuminate/support": "~5.0",
-    "illuminate/routing": "~5.0",
-    "illuminate/view": "~5.0"
+    "illuminate/cache": ">=5.0",
+    "illuminate/container": ">=5.0",
+    "illuminate/contracts": ">=5.0",
+    "illuminate/support": ">=5.0",
+    "illuminate/routing": ">=5.0",
+    "illuminate/view": ">=5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.1",

--- a/src/Append.php
+++ b/src/Append.php
@@ -41,6 +41,11 @@ interface Append extends Authorizable, Routeable
     public function url($url);
 
     /**
+     * @return string
+     */
+    public function getRoute();
+
+    /**
      * @param       $route
      * @param array $params
      *

--- a/src/Item.php
+++ b/src/Item.php
@@ -67,6 +67,11 @@ interface Item extends Itemable, Authorizable, Routeable
     public function url($url);
 
     /**
+     * @return string
+     */
+    public function getRoute();
+
+    /**
      * @param       $route
      * @param array $params
      *

--- a/src/Presentation/ActiveStateChecker.php
+++ b/src/Presentation/ActiveStateChecker.php
@@ -29,7 +29,7 @@ class ActiveStateChecker
         }
 
         if($route = $item->getRoute()) {
-            return Request::route()->getName() === $route;
+            return $this->getPartialRoute(Request::route()->getName()) === $this->getPartialRoute($route);
         }
 
         $path = ltrim(str_replace(url('/'), '', $item->getUrl()), '/');
@@ -38,5 +38,17 @@ class ActiveStateChecker
             $path,
             $path . '/*'
         );
+    }
+
+    protected function getPartialRoute($route, $delimiter = '.', $parts = 2)
+    {
+        $route = explode($delimiter, $route);
+        $routeParts = [];
+
+        for($part = 0; $part < $parts; $part++) {
+            $routeParts[] = $route[$part];
+        }
+
+        return implode($delimiter, $routeParts);
     }
 }

--- a/src/Presentation/ActiveStateChecker.php
+++ b/src/Presentation/ActiveStateChecker.php
@@ -28,6 +28,10 @@ class ActiveStateChecker
             );
         }
 
+        if($route = $item->getRoute()) {
+            return Request::route()->getName() === $route;
+        }
+
         $path = ltrim(str_replace(url('/'), '', $item->getUrl()), '/');
 
         return Request::is(

--- a/src/Routeable.php
+++ b/src/Routeable.php
@@ -17,6 +17,11 @@ interface Routeable
     public function url($url);
 
     /**
+     * @return string
+     */
+    public function getRoute();
+
+    /**
      * @param       $route
      * @param array $params
      *

--- a/src/Traits/RouteableTrait.php
+++ b/src/Traits/RouteableTrait.php
@@ -10,6 +10,11 @@ trait RouteableTrait
     protected $url = '#';
 
     /**
+     * @var string
+     */
+    protected $route = '';
+
+    /**
      * @return string
      */
     public function getUrl()
@@ -30,6 +35,14 @@ trait RouteableTrait
     }
 
     /**
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
      * @param       $route
      * @param array $params
      *
@@ -37,6 +50,8 @@ trait RouteableTrait
      */
     public function route($route, $params = [])
     {
+        $this->route = $route;
+
         $this->url(
             $this->container->make('url')->route($route, $params)
         );

--- a/tests/Traits/RouteableTraitTest.php
+++ b/tests/Traits/RouteableTraitTest.php
@@ -41,6 +41,18 @@ class RouteableTraitTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('url', $this->routeable->getUrl());
     }
+
+    public function test_can_get_route()
+    {
+        $urlMock = m::mock('Illuminate\Contracts\Routing\UrlGenerator');
+        $urlMock->shouldReceive('route')->andReturn('url');
+
+        $this->container->shouldReceive('make')->andReturn($urlMock);
+
+        $this->routeable->route('route');
+
+        $this->assertEquals('route', $this->routeable->getRoute());
+    }
 }
 
 class StubRouteableClass


### PR DESCRIPTION
I've added the ability to store the route name that is passed to the item and a corresponding getter method, so that you can check in the ActiveStateChecker if the current matched route is the one for the route.

Personally I'm using named routes a lot and when I create my sidebars I add the items using named routes, but the check for active state is failing when I have query parameters attached to the page - like for sorting or filtering data and the item in the sidebar is not set as active.

Also I guess this is a better way to check, rather than trying to partially match the current url. :)