### PR TITLE
fix Serializable warnings, fix tests etc..

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,43 @@
+name: run-tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        php: [ 8.1, 8.2 ]
+        laravel: [ 10 ]
+        stability: [ prefer-lowest, prefer-stable ]
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: |
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/pest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /vendor
+/build
+/.idea
 composer.phar
 composer.lock
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "maatwebsite/laravel-sidebar",
+  "name": "ozdemir/laravel-sidebar",
   "description": "A sidebar builder for Laravel",
   "license": "MIT",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -15,31 +15,35 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "illuminate/cache": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "illuminate/container": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "illuminate/contracts": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "illuminate/support": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "illuminate/routing": "~5.0|~6.0|~7.0|~8.0|~9.0",
-    "illuminate/view": "~5.0|~6.0|~7.0|~8.0|~9.0"
+    "php": ">=8.1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.1",
-    "mockery/mockery": "~0.9"
+    "pestphp/pest": "^2.0",
+    "orchestra/testbench": "^v8.5",
+    "nunomaduro/collision": "^7.0"
   },
   "autoload": {
     "psr-4": {
-      "Maatwebsite\\Sidebar\\": "src/"
+      "Maatwebsite\\Sidebar\\": "src/",
+      "Maatwebsite\\Sidebar\\Tests\\": "tests/"
     }
+  },
+  "scripts": {
+    "analyse": "vendor/bin/phpstan analyse",
+    "test": "vendor/bin/pest",
+    "test-coverage": "vendor/bin/pest --coverage"
   },
   "extra": {
     "laravel": {
-        "providers": [
-            "Maatwebsite\\Sidebar\\SidebarServiceProvider"
-        ]
+      "providers": [
+        "Maatwebsite\\Sidebar\\SidebarServiceProvider"
+      ]
     }
   },
   "config": {
-    "preferred-install": "dist"
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-        >
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Ozdemir Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
-    <testsuite name="Ozdemir Test Suite">
+    <testsuite name="Package Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,3 @@
-# WARNING! Not actively supported or maintained.
-
 # Laravel Sidebar
 
 [![GitHub release](https://img.shields.io/github/release/Maatwebsite/Laravel-Sidebar.svg?style=flat)](https://packagist.org/packages/maatwebsite/laravel-sidebar)

--- a/src/Domain/DefaultBadge.php
+++ b/src/Domain/DefaultBadge.php
@@ -83,4 +83,5 @@ class DefaultBadge implements Badge, Serializable
 
         return $this;
     }
+
 }

--- a/src/Traits/CacheableTrait.php
+++ b/src/Traits/CacheableTrait.php
@@ -9,14 +9,21 @@ trait CacheableTrait
      * @link http://php.net/manual/en/serializable.serialize.php
      * @return string the string representation of the object or null
      */
-    public function serialize()
+    public function serialize(): string
+    {
+        $cacheables = $this->__serialize();
+
+        return serialize($cacheables);
+    }
+
+    public function __serialize(): array
     {
         $cacheables = [];
         foreach ($this->getCacheables() as $cacheable) {
             $cacheables[$cacheable] = $this->{$cacheable};
         }
 
-        return serialize($cacheables);
+        return $cacheables;
     }
 
     /**
@@ -27,10 +34,15 @@ trait CacheableTrait
      *
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $data = unserialize($serialized);
 
+        $this->__unserialize($data);
+    }
+
+    public function __unserialize(array $data): void
+    {
         foreach ($data as $key => $value) {
             $this->{$key} = $value;
         }

--- a/src/Traits/CallableTrait.php
+++ b/src/Traits/CallableTrait.php
@@ -3,12 +3,12 @@
 namespace Maatwebsite\Sidebar\Traits;
 
 use Closure;
-use Illuminate\Routing\ResolvesRouteDependencies;
+use Illuminate\Routing\RouteDependencyResolverTrait;
 use ReflectionFunction;
 
 trait CallableTrait
 {
-    use ResolvesRouteDependencies;
+    use RouteDependencyResolverTrait;
 
     /**
      * Preform a callback on this workbook instance.

--- a/src/Traits/CallableTrait.php
+++ b/src/Traits/CallableTrait.php
@@ -3,22 +3,22 @@
 namespace Maatwebsite\Sidebar\Traits;
 
 use Closure;
-use Illuminate\Routing\RouteDependencyResolverTrait;
+use Illuminate\Routing\ResolvesRouteDependencies;
 use ReflectionFunction;
 
 trait CallableTrait
 {
-    use RouteDependencyResolverTrait;
+    use ResolvesRouteDependencies;
 
     /**
      * Preform a callback on this workbook instance.
      *
-     * @param callable $callback
-     * @param null     $caller
+     * @param Closure|string|null $callback
+     * @param null $caller
      *
-     * @return $this
+     * @throws \ReflectionException
      */
-    public function call(Closure $callback = null, $caller = null)
+    public function call(Closure|string $callback = null, $caller = null)
     {
         if ($callback instanceof Closure) {
             // Make dependency injection possible

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     */
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Domain/DefaultAppendTest.php
+++ b/tests/Domain/DefaultAppendTest.php
@@ -4,7 +4,7 @@ use Maatwebsite\Sidebar\Append;
 use Maatwebsite\Sidebar\Domain\DefaultAppend;
 use Mockery as m;
 
-class DefaultAppendTest extends PHPUnit_Framework_TestCase
+class DefaultAppendTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -16,8 +16,9 @@ class DefaultAppendTest extends PHPUnit_Framework_TestCase
      */
     protected $append;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->append    = new DefaultAppend($this->container);
     }

--- a/tests/Domain/DefaultBadgeTest.php
+++ b/tests/Domain/DefaultBadgeTest.php
@@ -4,7 +4,7 @@ use Maatwebsite\Sidebar\Badge;
 use Maatwebsite\Sidebar\Domain\DefaultBadge;
 use Mockery as m;
 
-class DefaultBadgeTest extends PHPUnit_Framework_TestCase
+class DefaultBadgeTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -16,8 +16,9 @@ class DefaultBadgeTest extends PHPUnit_Framework_TestCase
      */
     protected $badge;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container  = m::mock('Illuminate\Contracts\Container\Container');
         $this->badge      = new DefaultBadge($this->container);
     }

--- a/tests/Domain/DefaultGroupTest.php
+++ b/tests/Domain/DefaultGroupTest.php
@@ -5,7 +5,7 @@ use Maatwebsite\Sidebar\Domain\DefaultItem;
 use Maatwebsite\Sidebar\Group;
 use Mockery as m;
 
-class DefaultGroupTest extends PHPUnit_Framework_TestCase
+class DefaultGroupTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -17,8 +17,9 @@ class DefaultGroupTest extends PHPUnit_Framework_TestCase
      */
     protected $group;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->group     = new DefaultGroup($this->container);
     }

--- a/tests/Domain/DefaultItemTest.php
+++ b/tests/Domain/DefaultItemTest.php
@@ -6,7 +6,7 @@ use Maatwebsite\Sidebar\Domain\DefaultItem;
 use Maatwebsite\Sidebar\Item;
 use Mockery as m;
 
-class DefaultItemTest extends PHPUnit_Framework_TestCase
+class DefaultItemTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -18,8 +18,9 @@ class DefaultItemTest extends PHPUnit_Framework_TestCase
      */
     protected $item;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->item      = new DefaultItem($this->container);
     }

--- a/tests/Domain/DefaultMenuTest.php
+++ b/tests/Domain/DefaultMenuTest.php
@@ -5,7 +5,8 @@ use Maatwebsite\Sidebar\Domain\DefaultMenu;
 use Maatwebsite\Sidebar\Menu;
 use Mockery as m;
 
-class DefaultMenuTest extends PHPUnit_Framework_TestCase
+
+class DefaultMenuTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -17,8 +18,9 @@ class DefaultMenuTest extends PHPUnit_Framework_TestCase
      */
     protected $menu;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->menu      = new DefaultMenu($this->container);
     }
@@ -39,11 +41,16 @@ class DefaultMenuTest extends PHPUnit_Framework_TestCase
 
     public function test_menu_can_be_cached()
     {
-        $this->mockContainerMake();
-        $this->menu->group('test');
-        $this->menu->group('test2');
+        // Serialization of 'ReflectionClass' is not allowed
+        // So we use real objects here..
+        $menu = new DefaultMenu($this->container);
+        $group = new DefaultGroup($this->container);
+        $this->container->shouldReceive('make')->with('Maatwebsite\Sidebar\Group')->andReturn($group);
 
-        $serialized   = serialize($this->menu);
+        $menu->group('test');
+        $menu->group('test2');
+
+        $serialized = serialize($menu);
         $unserialized = unserialize($serialized);
 
         $this->assertInstanceOf('Maatwebsite\Sidebar\Menu', $unserialized);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Maatwebsite\Sidebar\Tests;
+
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/SidebarExtenderTest.php
+++ b/tests/SidebarExtenderTest.php
@@ -6,7 +6,7 @@ use Maatwebsite\Sidebar\Menu;
 use Maatwebsite\Sidebar\SidebarExtender;
 use Mockery as m;
 
-class SidebarExtenderTest extends PHPUnit_Framework_TestCase
+class SidebarExtenderTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -18,8 +18,9 @@ class SidebarExtenderTest extends PHPUnit_Framework_TestCase
      */
     protected $menu;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->menu      = new DefaultMenu($this->container);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Maatwebsite\Sidebar\Tests;
+
+use Illuminate\Events\Dispatcher;
+use Maatwebsite\Sidebar\Domain\DefaultMenu;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+
+class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        config()->set('database.default', 'testing');
+    }
+}

--- a/tests/Traits/AuthorizableTraitTest.php
+++ b/tests/Traits/AuthorizableTraitTest.php
@@ -2,15 +2,16 @@
 
 use Maatwebsite\Sidebar\Traits\AuthorizableTrait;
 
-class AuthorizableTraitTest extends PHPUnit_Framework_TestCase
+class AuthorizableTraitTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var StubItemableClass
      */
     protected $routeable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->routeable = new StubAuthorizableClass();
     }
 

--- a/tests/Traits/ItemableTraitTest.php
+++ b/tests/Traits/ItemableTraitTest.php
@@ -8,7 +8,7 @@ use Maatwebsite\Sidebar\Traits\CallableTrait;
 use Maatwebsite\Sidebar\Traits\ItemableTrait;
 use Mockery as m;
 
-class ItemableTraitTest extends PHPUnit_Framework_TestCase
+class ItemableTraitTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -20,8 +20,9 @@ class ItemableTraitTest extends PHPUnit_Framework_TestCase
      */
     protected $itemable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->itemable  = new StubItemableClass($this->container);
     }

--- a/tests/Traits/RouteableTraitTest.php
+++ b/tests/Traits/RouteableTraitTest.php
@@ -5,7 +5,7 @@ use Maatwebsite\Sidebar\Routeable;
 use Maatwebsite\Sidebar\Traits\RouteableTrait;
 use Mockery as m;
 
-class RouteableTraitTest extends PHPUnit_Framework_TestCase
+class RouteableTraitTest extends \Maatwebsite\Sidebar\Tests\TestCase
 {
     /**
      * @var Illuminate\Contracts\Container\Container
@@ -17,8 +17,9 @@ class RouteableTraitTest extends PHPUnit_Framework_TestCase
      */
     protected $routeable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->container = m::mock('Illuminate\Contracts\Container\Container');
         $this->routeable = new StubRouteableClass($this->container);
     }


### PR DESCRIPTION
Hey @patrickbrouwers,
I have updated the library for laravel 9+ and php8.1, also fixed Serializable warnings.. 

But I think it needs a major version update in order to maintain compatibility with already existing integrations. 